### PR TITLE
Fix bug where config file cannot be found on DB warmup

### DIFF
--- a/Automated_install_script.sh
+++ b/Automated_install_script.sh
@@ -294,7 +294,7 @@ cat <<EOF >${WorkingDirectoryTelegram}/config/custom_scripts.json
   "🦸 Appreciate Masa": "echo Masa is great",
   "Crypto chart": "python3 ../binance-chart-plugin-telegram-bot/db_chart.py",
   "Update crypto chart": "bash -c 'cd ../binance-chart-plugin-telegram-bot && git pull'",
-  "Database warmup": "python3 ../binance-trade-bot/database_warmup.py"
+  "Database warmup": "cd ../binance-trade-bot && python3 database_warmup.py"
 }
 EOF
 else


### PR DESCRIPTION
Fixing bug causing error when running database warmup from Telegram bot. The the database_warmup.py script in the TnTwist form requires access to config, however it couldn't be found due to being in the Telegram bot directory. Solution was to change directory before execution of script.